### PR TITLE
채팅 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,12 @@ dependencies {
     // web socket
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
 
+    // querydsl
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.h2database:h2'
@@ -83,4 +89,22 @@ bootJar {
     from("${asciidoctor.outputDir}") {
         into 'static/docs'
     }
+}
+
+// Querydsl 설정부
+def generated = 'src/main/generated'
+
+// querydsl QClass 파일 생성 위치를 지정
+tasks.withType(JavaCompile) {
+    options.getGeneratedSourceOutputDirectory().set(file(generated))
+}
+
+// java source set 에 querydsl QClass 위치 추가
+sourceSets {
+    main.java.srcDirs += [ generated ]
+}
+
+// gradle clean 시에 QClass 디렉토리 삭제
+clean {
+    delete file(generated)
 }

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,9 @@ dependencies {
     asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 
+    // web socket
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
+
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.h2database:h2'

--- a/src/main/generated/com/sejongmate/chat/domain/QChatMessage.java
+++ b/src/main/generated/com/sejongmate/chat/domain/QChatMessage.java
@@ -1,0 +1,64 @@
+package com.sejongmate.chat.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QChatMessage is a Querydsl query type for ChatMessage
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QChatMessage extends EntityPathBase<ChatMessage> {
+
+    private static final long serialVersionUID = -1744488369L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QChatMessage chatMessage = new QChatMessage("chatMessage");
+
+    public final StringPath content = createString("content");
+
+    public final DateTimePath<java.time.LocalDateTime> createdAt = createDateTime("createdAt", java.time.LocalDateTime.class);
+
+    public final StringPath fileUrl = createString("fileUrl");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final BooleanPath isNotice = createBoolean("isNotice");
+
+    public final QChatRoom room;
+
+    public final com.sejongmate.user.domain.QUser sender;
+
+    public final EnumPath<MessageType> type = createEnum("type", MessageType.class);
+
+    public QChatMessage(String variable) {
+        this(ChatMessage.class, forVariable(variable), INITS);
+    }
+
+    public QChatMessage(Path<? extends ChatMessage> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QChatMessage(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QChatMessage(PathMetadata metadata, PathInits inits) {
+        this(ChatMessage.class, metadata, inits);
+    }
+
+    public QChatMessage(Class<? extends ChatMessage> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.room = inits.isInitialized("room") ? new QChatRoom(forProperty("room")) : null;
+        this.sender = inits.isInitialized("sender") ? new com.sejongmate.user.domain.QUser(forProperty("sender")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/sejongmate/chat/domain/QChatParticipant.java
+++ b/src/main/generated/com/sejongmate/chat/domain/QChatParticipant.java
@@ -1,0 +1,54 @@
+package com.sejongmate.chat.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QChatParticipant is a Querydsl query type for ChatParticipant
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QChatParticipant extends EntityPathBase<ChatParticipant> {
+
+    private static final long serialVersionUID = -1997356165L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QChatParticipant chatParticipant = new QChatParticipant("chatParticipant");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final QChatRoom room;
+
+    public final com.sejongmate.user.domain.QUser user;
+
+    public QChatParticipant(String variable) {
+        this(ChatParticipant.class, forVariable(variable), INITS);
+    }
+
+    public QChatParticipant(Path<? extends ChatParticipant> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QChatParticipant(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QChatParticipant(PathMetadata metadata, PathInits inits) {
+        this(ChatParticipant.class, metadata, inits);
+    }
+
+    public QChatParticipant(Class<? extends ChatParticipant> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.room = inits.isInitialized("room") ? new QChatRoom(forProperty("room")) : null;
+        this.user = inits.isInitialized("user") ? new com.sejongmate.user.domain.QUser(forProperty("user")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/sejongmate/chat/domain/QChatRoom.java
+++ b/src/main/generated/com/sejongmate/chat/domain/QChatRoom.java
@@ -1,0 +1,46 @@
+package com.sejongmate.chat.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QChatRoom is a Querydsl query type for ChatRoom
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QChatRoom extends EntityPathBase<ChatRoom> {
+
+    private static final long serialVersionUID = -719884909L;
+
+    public static final QChatRoom chatRoom = new QChatRoom("chatRoom");
+
+    public final NumberPath<Integer> count = createNumber("count", Integer.class);
+
+    public final DateTimePath<java.time.LocalDateTime> createdAt = createDateTime("createdAt", java.time.LocalDateTime.class);
+
+    public final StringPath id = createString("id");
+
+    public final StringPath name = createString("name");
+
+    public final ListPath<ChatParticipant, QChatParticipant> participants = this.<ChatParticipant, QChatParticipant>createList("participants", ChatParticipant.class, QChatParticipant.class, PathInits.DIRECT2);
+
+    public QChatRoom(String variable) {
+        super(ChatRoom.class, forVariable(variable));
+    }
+
+    public QChatRoom(Path<? extends ChatRoom> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QChatRoom(PathMetadata metadata) {
+        super(ChatRoom.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/com/sejongmate/chat/presentation/dto/QChatRoomHistoryDto.java
+++ b/src/main/generated/com/sejongmate/chat/presentation/dto/QChatRoomHistoryDto.java
@@ -1,0 +1,21 @@
+package com.sejongmate.chat.presentation.dto;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.ConstructorExpression;
+import javax.annotation.processing.Generated;
+
+/**
+ * com.sejongmate.chat.presentation.dto.QChatRoomHistoryDto is a Querydsl Projection type for ChatRoomHistoryDto
+ */
+@Generated("com.querydsl.codegen.DefaultProjectionSerializer")
+public class QChatRoomHistoryDto extends ConstructorExpression<ChatRoomHistoryDto> {
+
+    private static final long serialVersionUID = -947360905L;
+
+    public QChatRoomHistoryDto(com.querydsl.core.types.Expression<String> name, com.querydsl.core.types.Expression<String> profileUrl, com.querydsl.core.types.Expression<String> content, com.querydsl.core.types.Expression<java.time.LocalDateTime> createdAt) {
+        super(ChatRoomHistoryDto.class, new Class<?>[]{String.class, String.class, String.class, java.time.LocalDateTime.class}, name, profileUrl, content, createdAt);
+    }
+
+}
+

--- a/src/main/generated/com/sejongmate/chat/presentation/dto/QChatRoomInfoDto.java
+++ b/src/main/generated/com/sejongmate/chat/presentation/dto/QChatRoomInfoDto.java
@@ -1,0 +1,21 @@
+package com.sejongmate.chat.presentation.dto;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.ConstructorExpression;
+import javax.annotation.processing.Generated;
+
+/**
+ * com.sejongmate.chat.presentation.dto.QChatRoomInfoDto is a Querydsl Projection type for ChatRoomInfoDto
+ */
+@Generated("com.querydsl.codegen.DefaultProjectionSerializer")
+public class QChatRoomInfoDto extends ConstructorExpression<ChatRoomInfoDto> {
+
+    private static final long serialVersionUID = 277388037L;
+
+    public QChatRoomInfoDto(com.querydsl.core.types.Expression<String> roomId, com.querydsl.core.types.Expression<String> name, com.querydsl.core.types.Expression<java.time.LocalDateTime> lastMessageAt, com.querydsl.core.types.Expression<String> lastMessage, com.querydsl.core.types.Expression<Integer> num) {
+        super(ChatRoomInfoDto.class, new Class<?>[]{String.class, String.class, java.time.LocalDateTime.class, String.class, int.class}, roomId, name, lastMessageAt, lastMessage, num);
+    }
+
+}
+

--- a/src/main/generated/com/sejongmate/common/domain/QBaseTimeEntity.java
+++ b/src/main/generated/com/sejongmate/common/domain/QBaseTimeEntity.java
@@ -1,0 +1,39 @@
+package com.sejongmate.common.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QBaseTimeEntity is a Querydsl query type for BaseTimeEntity
+ */
+@Generated("com.querydsl.codegen.DefaultSupertypeSerializer")
+public class QBaseTimeEntity extends EntityPathBase<BaseTimeEntity> {
+
+    private static final long serialVersionUID = 219208532L;
+
+    public static final QBaseTimeEntity baseTimeEntity = new QBaseTimeEntity("baseTimeEntity");
+
+    public final DateTimePath<java.time.LocalDateTime> createdDate = createDateTime("createdDate", java.time.LocalDateTime.class);
+
+    public final DateTimePath<java.time.LocalDateTime> lastModifiedDate = createDateTime("lastModifiedDate", java.time.LocalDateTime.class);
+
+    public QBaseTimeEntity(String variable) {
+        super(BaseTimeEntity.class, forVariable(variable));
+    }
+
+    public QBaseTimeEntity(Path<? extends BaseTimeEntity> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QBaseTimeEntity(PathMetadata metadata) {
+        super(BaseTimeEntity.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/com/sejongmate/user/domain/QUser.java
+++ b/src/main/generated/com/sejongmate/user/domain/QUser.java
@@ -1,0 +1,61 @@
+package com.sejongmate.user.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QUser is a Querydsl query type for User
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QUser extends EntityPathBase<User> {
+
+    private static final long serialVersionUID = 1167925502L;
+
+    public static final QUser user = new QUser("user");
+
+    public final com.sejongmate.common.domain.QBaseTimeEntity _super = new com.sejongmate.common.domain.QBaseTimeEntity(this);
+
+    public final StringPath contact = createString("contact");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdDate = _super.createdDate;
+
+    public final StringPath department = createString("department");
+
+    public final StringPath email = createString("email");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> lastModifiedDate = _super.lastModifiedDate;
+
+    public final StringPath name = createString("name");
+
+    public final StringPath num = createString("num");
+
+    public final StringPath password = createString("password");
+
+    public final StringPath profileUrl = createString("profileUrl");
+
+    public final EnumPath<Role> role = createEnum("role", Role.class);
+
+    public QUser(String variable) {
+        super(User.class, forVariable(variable));
+    }
+
+    public QUser(Path<? extends User> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QUser(PathMetadata metadata) {
+        super(User.class, metadata);
+    }
+
+}
+

--- a/src/main/java/com/sejongmate/chat/application/ChatService.java
+++ b/src/main/java/com/sejongmate/chat/application/ChatService.java
@@ -1,0 +1,61 @@
+package com.sejongmate.chat.application;
+
+import com.sejongmate.chat.domain.ChatMessage;
+import com.sejongmate.chat.domain.ChatMessageRepository;
+import com.sejongmate.chat.domain.ChatRoom;
+import com.sejongmate.chat.domain.ChatRoomRepository;
+import com.sejongmate.chat.presentation.dto.ChatMessageReqDto;
+import com.sejongmate.chat.presentation.dto.ChatMessageResDto;
+import com.sejongmate.common.BaseException;
+import com.sejongmate.user.domain.User;
+import com.sejongmate.user.domain.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+import static com.sejongmate.common.BaseResponseStatus.INVALID_CHATROOM;
+import static com.sejongmate.common.BaseResponseStatus.INVALID_USER_NUM;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+@Log4j2
+public class ChatService {
+
+    private final ChatMessageRepository chatMessageRepository;
+    private final ChatRoomRepository chatRoomRepository;
+    private final UserRepository userRepository;
+    @Transactional
+    public ChatMessageResDto sendMessage(ChatMessageReqDto chatMessageReqDto) throws BaseException {
+
+        ChatRoom room = chatRoomRepository.findById(chatMessageReqDto.getRoomId())
+                .orElseThrow(() -> {
+                    log.error(INVALID_CHATROOM.getMessage());
+                    return new BaseException(INVALID_CHATROOM);
+                });
+
+        User user = userRepository.findById(chatMessageReqDto.getSenderId()).orElseThrow(() -> {
+            log.error(INVALID_USER_NUM.getMessage());
+            return  new BaseException(INVALID_USER_NUM);
+        });
+
+
+        ChatMessage message = ChatMessage.builder()
+                .type(chatMessageReqDto.getType())
+                .room(room)
+                .sender(user)
+                .content(chatMessageReqDto.getContent())
+                .createdAt(LocalDateTime.now())
+                .isNotice(chatMessageReqDto.getIsNotice())
+                .fileUrl(chatMessageReqDto.getFileUrl())
+                .build();
+
+        chatMessageRepository.save(message);
+
+        return ChatMessageResDto.from(message);
+
+    }
+}

--- a/src/main/java/com/sejongmate/chat/application/ChatService.java
+++ b/src/main/java/com/sejongmate/chat/application/ChatService.java
@@ -1,16 +1,11 @@
 package com.sejongmate.chat.application;
 
 import com.sejongmate.chat.domain.*;
-import com.sejongmate.chat.presentation.dto.ChatMessageReqDto;
-import com.sejongmate.chat.presentation.dto.ChatMessageResDto;
-import com.sejongmate.chat.presentation.dto.ChatRoomReqDto;
-import com.sejongmate.chat.presentation.dto.ChatRoomResDto;
+import com.sejongmate.chat.infra.ChatQueryDao;
+import com.sejongmate.chat.presentation.dto.*;
 import com.sejongmate.common.BaseException;
 import com.sejongmate.user.domain.User;
 import com.sejongmate.user.domain.UserRepository;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.OneToMany;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.stereotype.Service;
@@ -33,6 +28,7 @@ public class ChatService {
     private final ChatMessageRepository chatMessageRepository;
     private final ChatRoomRepository chatRoomRepository;
     private final UserRepository userRepository;
+    private final ChatQueryDao chatQueryDao;
 
     @Transactional
     public ChatMessageResDto sendMessage(ChatMessageReqDto chatMessageReqDto) throws BaseException {
@@ -48,7 +44,6 @@ public class ChatService {
             return  new BaseException(INVALID_USER_NUM);
         });
 
-
         ChatMessage message = ChatMessage.builder()
                 .type(chatMessageReqDto.getType())
                 .room(room)
@@ -58,6 +53,8 @@ public class ChatService {
                 .isNotice(Boolean.FALSE)
                 .fileUrl(chatMessageReqDto.getFileUrl())
                 .build();
+
+
 
         chatMessageRepository.save(message);
 
@@ -87,5 +84,10 @@ public class ChatService {
         chatRoomRepository.save(room);
 
         return ChatRoomResDto.from(room);
+    }
+
+
+    public List<ChatRoomInfoDto> getChatRoomList(Long id) {
+        return chatQueryDao.getChatRoomInfo(id);
     }
 }

--- a/src/main/java/com/sejongmate/chat/application/ChatService.java
+++ b/src/main/java/com/sejongmate/chat/application/ChatService.java
@@ -54,8 +54,6 @@ public class ChatService {
                 .fileUrl(chatMessageReqDto.getFileUrl())
                 .build();
 
-
-
         chatMessageRepository.save(message);
 
         return ChatMessageResDto.from(message);
@@ -89,5 +87,14 @@ public class ChatService {
 
     public List<ChatRoomInfoDto> getChatRoomList(Long id) {
         return chatQueryDao.getChatRoomInfo(id);
+    }
+
+    public List<ChatRoomHistoryDto> getChatRoomHistory(String id){
+        return chatQueryDao.getChatRoomHistory(id);
+    }
+
+    @Transactional
+    public Boolean deleteChatRoomUser(String roomId, Long userId) {
+        return chatQueryDao.deleteChatRoomUser(roomId, userId);
     }
 }

--- a/src/main/java/com/sejongmate/chat/domain/ChatMessage.java
+++ b/src/main/java/com/sejongmate/chat/domain/ChatMessage.java
@@ -1,0 +1,37 @@
+package com.sejongmate.chat.domain;
+
+import com.sejongmate.user.domain.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatMessage {
+    public enum MessageType{
+        MESSAGE, IMAGE
+    }
+
+    @Id
+    @Column(name = "message_id")
+    private Long id;
+    @Enumerated(EnumType.STRING)
+    private MessageType type;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "room_id")
+    private ChatRoom room;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sender_id")
+    private User sender;
+    private String content;
+    private LocalDateTime createdAt;
+    private Boolean isNotice;
+    private String fileUrl;
+
+}

--- a/src/main/java/com/sejongmate/chat/domain/ChatMessage.java
+++ b/src/main/java/com/sejongmate/chat/domain/ChatMessage.java
@@ -3,6 +3,7 @@ package com.sejongmate.chat.domain;
 import com.sejongmate.user.domain.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -12,10 +13,6 @@ import java.time.LocalDateTime;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ChatMessage {
-    public enum MessageType{
-        MESSAGE, IMAGE
-    }
-
     @Id
     @Column(name = "message_id")
     private Long id;
@@ -34,4 +31,14 @@ public class ChatMessage {
     private Boolean isNotice;
     private String fileUrl;
 
+    @Builder
+    public ChatMessage(MessageType type, ChatRoom room, User sender, String content, LocalDateTime createdAt, Boolean isNotice, String fileUrl) {
+        this.type = type;
+        this.room = room;
+        this.sender = sender;
+        this.content = content;
+        this.createdAt = createdAt;
+        this.isNotice = isNotice;
+        this.fileUrl = fileUrl;
+    }
 }

--- a/src/main/java/com/sejongmate/chat/domain/ChatMessage.java
+++ b/src/main/java/com/sejongmate/chat/domain/ChatMessage.java
@@ -15,6 +15,7 @@ import java.time.LocalDateTime;
 public class ChatMessage {
     @Id
     @Column(name = "message_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @Enumerated(EnumType.STRING)
     private MessageType type;

--- a/src/main/java/com/sejongmate/chat/domain/ChatMessageRepository.java
+++ b/src/main/java/com/sejongmate/chat/domain/ChatMessageRepository.java
@@ -1,0 +1,7 @@
+package com.sejongmate.chat.domain;
+
+import com.sejongmate.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+}

--- a/src/main/java/com/sejongmate/chat/domain/ChatParticipant.java
+++ b/src/main/java/com/sejongmate/chat/domain/ChatParticipant.java
@@ -3,6 +3,7 @@ package com.sejongmate.chat.domain;
 import com.sejongmate.user.domain.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -23,4 +24,9 @@ public class ChatParticipant {
     @JoinColumn(name = "user_id")
     private User user;
 
+    @Builder
+    public ChatParticipant(ChatRoom room, User user) {
+        this.room = room;
+        this.user = user;
+    }
 }

--- a/src/main/java/com/sejongmate/chat/domain/ChatParticipant.java
+++ b/src/main/java/com/sejongmate/chat/domain/ChatParticipant.java
@@ -1,0 +1,26 @@
+package com.sejongmate.chat.domain;
+
+import com.sejongmate.user.domain.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatParticipant {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "participant_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "room_id")
+    private ChatRoom room;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+}

--- a/src/main/java/com/sejongmate/chat/domain/ChatParticipantRepository.java
+++ b/src/main/java/com/sejongmate/chat/domain/ChatParticipantRepository.java
@@ -1,0 +1,6 @@
+package com.sejongmate.chat.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatParticipantRepository extends JpaRepository<ChatRoom, Long> {
+}

--- a/src/main/java/com/sejongmate/chat/domain/ChatRoom.java
+++ b/src/main/java/com/sejongmate/chat/domain/ChatRoom.java
@@ -22,15 +22,18 @@ public class ChatRoom {
     private String name;
     private LocalDateTime createdAt;
 
+    private Integer count;
+
 //    @JsonIgnore
     @OneToMany(mappedBy = "room", cascade = CascadeType.ALL)
     private List<ChatParticipant> participants;
 
     @Builder
-    public ChatRoom(String id, String name, LocalDateTime createdAt, List<ChatParticipant> participants) {
+    public ChatRoom(String id, String name, LocalDateTime createdAt, Integer count, List<ChatParticipant> participants) {
         this.id = id;
         this.name = name;
         this.createdAt = createdAt;
+        this.count = count;
         this.participants = participants;
     }
 
@@ -42,6 +45,7 @@ public class ChatRoom {
         chatRoom.id = randomId;
         chatRoom.name = name;
         chatRoom.createdAt = LocalDateTime.now();
+        chatRoom.count = 0;
         chatRoom.participants = new ArrayList<>();
 
         return chatRoom;
@@ -51,6 +55,7 @@ public class ChatRoom {
     public void insertParticipants(List<ChatParticipant> chatParticipants){
         for (ChatParticipant participant : chatParticipants) {
             this.participants.add(participant);
+            this.count += 1;
         }
     }
 }

--- a/src/main/java/com/sejongmate/chat/domain/ChatRoom.java
+++ b/src/main/java/com/sejongmate/chat/domain/ChatRoom.java
@@ -1,0 +1,26 @@
+package com.sejongmate.chat.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatRoom {
+    @Id
+    @Column(name = "room_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private String id;
+    private String name;
+    private LocalDateTime createdAt;
+
+//    @JsonIgnore
+    @OneToMany(mappedBy = "room")
+    private List<ChatParticipant> participants;
+}

--- a/src/main/java/com/sejongmate/chat/domain/ChatRoom.java
+++ b/src/main/java/com/sejongmate/chat/domain/ChatRoom.java
@@ -3,11 +3,14 @@ package com.sejongmate.chat.domain;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 @Entity
 @Getter
@@ -15,12 +18,40 @@ import java.util.List;
 public class ChatRoom {
     @Id
     @Column(name = "room_id")
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private String id;
     private String name;
     private LocalDateTime createdAt;
 
 //    @JsonIgnore
-    @OneToMany(mappedBy = "room")
+    @OneToMany(mappedBy = "room", cascade = CascadeType.ALL)
     private List<ChatParticipant> participants;
+
+    @Builder
+    public ChatRoom(String id, String name, LocalDateTime createdAt, List<ChatParticipant> participants) {
+        this.id = id;
+        this.name = name;
+        this.createdAt = createdAt;
+        this.participants = participants;
+    }
+
+    //==생성 메서드==//
+    public static ChatRoom createChatRoom(String name){
+        ChatRoom chatRoom = new ChatRoom();
+        String randomId = UUID.randomUUID().toString();
+
+        chatRoom.id = randomId;
+        chatRoom.name = name;
+        chatRoom.createdAt = LocalDateTime.now();
+        chatRoom.participants = new ArrayList<>();
+
+        return chatRoom;
+    }
+
+    //==비지니스 로직==//
+    public void insertParticipants(List<ChatParticipant> chatParticipants){
+        for (ChatParticipant participant : chatParticipants) {
+            this.participants.add(participant);
+        }
+    }
 }
+

--- a/src/main/java/com/sejongmate/chat/domain/ChatRoomRepository.java
+++ b/src/main/java/com/sejongmate/chat/domain/ChatRoomRepository.java
@@ -1,0 +1,10 @@
+package com.sejongmate.chat.domain;
+
+import com.sejongmate.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+    Optional<ChatRoom> findById(String Id);
+}

--- a/src/main/java/com/sejongmate/chat/domain/MessageType.java
+++ b/src/main/java/com/sejongmate/chat/domain/MessageType.java
@@ -1,0 +1,5 @@
+package com.sejongmate.chat.domain;
+
+public enum MessageType{
+    MESSAGE, IMAGE
+}

--- a/src/main/java/com/sejongmate/chat/infra/ChatQueryDao.java
+++ b/src/main/java/com/sejongmate/chat/infra/ChatQueryDao.java
@@ -1,9 +1,12 @@
 package com.sejongmate.chat.infra;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.sejongmate.chat.presentation.dto.ChatRoomHistoryDto;
 import com.sejongmate.chat.presentation.dto.ChatRoomInfoDto;
+import com.sejongmate.chat.presentation.dto.QChatRoomHistoryDto;
 import com.sejongmate.chat.presentation.dto.QChatRoomInfoDto;
 import com.sejongmate.common.util.DeduplicationUtils;
+import com.sejongmate.user.domain.QUser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -11,6 +14,7 @@ import java.util.List;
 import static com.sejongmate.chat.domain.QChatMessage.chatMessage;
 import static com.sejongmate.chat.domain.QChatParticipant.chatParticipant;
 import static com.sejongmate.chat.domain.QChatRoom.chatRoom;
+import static com.sejongmate.user.domain.QUser.user;
 
 @RequiredArgsConstructor
 @Repository
@@ -18,8 +22,6 @@ public class ChatQueryDao {
     private final JPAQueryFactory query;
 
     public List<ChatRoomInfoDto> getChatRoomInfo(Long id){
-
-
         List<ChatRoomInfoDto> chatRoomInfoDtos = query
                 .select(new QChatRoomInfoDto(chatRoom.id, chatRoom.name,
                         chatMessage.createdAt, chatMessage.content, chatRoom.count
@@ -34,4 +36,20 @@ public class ChatQueryDao {
         return DeduplicationUtils.deduplication(chatRoomInfoDtos, ChatRoomInfoDto::getRoomId);
     }
 
+    public List<ChatRoomHistoryDto> getChatRoomHistory(String id) {
+        return query
+                .select(new QChatRoomHistoryDto(user.name, user.profileUrl, chatMessage.content, chatMessage.createdAt))
+                .from(chatMessage)
+                .where(chatMessage.room.id.eq(id))
+                .leftJoin(user).on(chatMessage.sender.id.eq(user.id))
+                .orderBy(chatMessage.createdAt.asc())
+                .fetch();
+    }
+
+    public Boolean deleteChatRoomUser(String roomId, Long userId){
+        long result = query.delete(chatParticipant)
+                .where(chatParticipant.room.id.eq(roomId), chatParticipant.user.id.eq(userId))
+                .execute();
+        return result == 1? true : false;
+    }
 }

--- a/src/main/java/com/sejongmate/chat/infra/ChatQueryDao.java
+++ b/src/main/java/com/sejongmate/chat/infra/ChatQueryDao.java
@@ -1,0 +1,37 @@
+package com.sejongmate.chat.infra;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.sejongmate.chat.presentation.dto.ChatRoomInfoDto;
+import com.sejongmate.chat.presentation.dto.QChatRoomInfoDto;
+import com.sejongmate.common.util.DeduplicationUtils;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import static com.sejongmate.chat.domain.QChatMessage.chatMessage;
+import static com.sejongmate.chat.domain.QChatParticipant.chatParticipant;
+import static com.sejongmate.chat.domain.QChatRoom.chatRoom;
+
+@RequiredArgsConstructor
+@Repository
+public class ChatQueryDao {
+    private final JPAQueryFactory query;
+
+    public List<ChatRoomInfoDto> getChatRoomInfo(Long id){
+
+
+        List<ChatRoomInfoDto> chatRoomInfoDtos = query
+                .select(new QChatRoomInfoDto(chatRoom.id, chatRoom.name,
+                        chatMessage.createdAt, chatMessage.content, chatRoom.count
+                ))
+                .from(chatRoom)
+                .where(chatParticipant.user.id.eq(id))
+                .leftJoin(chatMessage).on(chatMessage.room.id.eq(chatRoom.id))
+                .leftJoin(chatParticipant).on(chatParticipant.room.id.eq(chatRoom.id))
+                .orderBy(chatMessage.createdAt.desc())
+                .fetch();
+
+        return DeduplicationUtils.deduplication(chatRoomInfoDtos, ChatRoomInfoDto::getRoomId);
+    }
+
+}

--- a/src/main/java/com/sejongmate/chat/presentation/ChatController.java
+++ b/src/main/java/com/sejongmate/chat/presentation/ChatController.java
@@ -1,0 +1,40 @@
+package com.sejongmate.chat.presentation;
+
+import com.sejongmate.chat.application.ChatService;
+import com.sejongmate.chat.presentation.dto.ChatMessageReqDto;
+import com.sejongmate.chat.presentation.dto.ChatMessageResDto;
+import com.sejongmate.common.BaseException;
+import com.sejongmate.common.BaseResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/chat")
+@Log4j2
+public class ChatController {
+    private final ChatService chatService;
+
+    @PostMapping("/send")
+    public BaseResponse<ChatMessageResDto> sendMessage(@Valid @RequestBody ChatMessageReqDto chatMessageReqDto, BindingResult br) {
+
+        // 형식적 validation
+        if (br.hasErrors()){
+            String errorName = br.getAllErrors().get(0).getDefaultMessage(); //dto에 선언한 에러
+            log.error(errorName);
+            return new BaseResponse<>(errorName);
+        }
+
+        try {
+            return new BaseResponse<>(chatService.sendMessage(chatMessageReqDto));
+        } catch(BaseException e){
+            return new BaseResponse<>(e.getStatus());
+        }
+    }
+}

--- a/src/main/java/com/sejongmate/chat/presentation/ChatController.java
+++ b/src/main/java/com/sejongmate/chat/presentation/ChatController.java
@@ -1,20 +1,16 @@
 package com.sejongmate.chat.presentation;
 
 import com.sejongmate.chat.application.ChatService;
-import com.sejongmate.chat.presentation.dto.ChatMessageReqDto;
-import com.sejongmate.chat.presentation.dto.ChatMessageResDto;
-import com.sejongmate.chat.presentation.dto.ChatRoomReqDto;
-import com.sejongmate.chat.presentation.dto.ChatRoomResDto;
+import com.sejongmate.chat.presentation.dto.*;
 import com.sejongmate.common.BaseException;
 import com.sejongmate.common.BaseResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.validation.BindingResult;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @RestController
@@ -52,6 +48,14 @@ public class ChatController {
         } catch(BaseException e){
             return new BaseResponse<>(e.getStatus());
         }
+    }
 
+    @GetMapping("/room/{id}")
+    public BaseResponse<List<ChatRoomInfoDto>> getChatRoomList(@PathVariable("id") Long id){
+        try {
+            return new BaseResponse<>(chatService.getChatRoomList(id));
+        } catch(BaseException e){
+            return new BaseResponse<>(e.getStatus());
+        }
     }
 }

--- a/src/main/java/com/sejongmate/chat/presentation/ChatController.java
+++ b/src/main/java/com/sejongmate/chat/presentation/ChatController.java
@@ -19,6 +19,9 @@ import java.util.List;
 public class ChatController {
     private final ChatService chatService;
 
+    /**
+     * 채팅 생성
+     */
     @PostMapping("/message")
     public BaseResponse<ChatMessageResDto> sendMessage(@Valid @RequestBody ChatMessageReqDto chatMessageReqDto, BindingResult br) {
 
@@ -35,6 +38,9 @@ public class ChatController {
         }
     }
 
+    /**
+     * 채팅방 생성
+     */
     @PostMapping("/room")
     public BaseResponse<ChatRoomResDto> createChatRoom(@Valid @RequestBody ChatRoomReqDto chatRoomReqDto, BindingResult br){
         if (br.hasErrors()){
@@ -50,12 +56,40 @@ public class ChatController {
         }
     }
 
-    @GetMapping("/room/{id}")
-    public BaseResponse<List<ChatRoomInfoDto>> getChatRoomList(@PathVariable("id") Long id){
+    /**
+     * 유저의 채팅방 목록 조회
+     */
+    @GetMapping("/room/list/{user_id}")
+    public BaseResponse<List<ChatRoomInfoDto>> getChatRoomList(@PathVariable("user_id") Long id){
         try {
             return new BaseResponse<>(chatService.getChatRoomList(id));
         } catch(BaseException e){
             return new BaseResponse<>(e.getStatus());
         }
     }
+
+    /**
+     * 채팅방 채팅 목록 조회
+     */
+    @GetMapping("/room/{room_id}")
+    public BaseResponse<List<ChatRoomHistoryDto>> getChatRoomHistory(@PathVariable("room_id") String id){
+        try {
+            return new BaseResponse<>(chatService.getChatRoomHistory(id));
+        } catch(BaseException e){
+            return new BaseResponse<>(e.getStatus());
+        }
+    }
+
+    /**
+     * 채팅방 나가기
+     */
+    @DeleteMapping("/room/{room_id}/{user_id}")
+    public BaseResponse<Boolean> deleteChatRoomUser(@PathVariable("room_id") String roomId, @PathVariable("user_id") Long userId){
+        try {
+            return new BaseResponse<>(chatService.deleteChatRoomUser(roomId, userId));
+        } catch(BaseException e){
+            return new BaseResponse<>(e.getStatus());
+        }
+    }
+
 }

--- a/src/main/java/com/sejongmate/chat/presentation/ChatController.java
+++ b/src/main/java/com/sejongmate/chat/presentation/ChatController.java
@@ -3,6 +3,8 @@ package com.sejongmate.chat.presentation;
 import com.sejongmate.chat.application.ChatService;
 import com.sejongmate.chat.presentation.dto.ChatMessageReqDto;
 import com.sejongmate.chat.presentation.dto.ChatMessageResDto;
+import com.sejongmate.chat.presentation.dto.ChatRoomReqDto;
+import com.sejongmate.chat.presentation.dto.ChatRoomResDto;
 import com.sejongmate.common.BaseException;
 import com.sejongmate.common.BaseResponse;
 import jakarta.validation.Valid;
@@ -21,12 +23,11 @@ import org.springframework.web.bind.annotation.RestController;
 public class ChatController {
     private final ChatService chatService;
 
-    @PostMapping("/send")
+    @PostMapping("/message")
     public BaseResponse<ChatMessageResDto> sendMessage(@Valid @RequestBody ChatMessageReqDto chatMessageReqDto, BindingResult br) {
 
-        // 형식적 validation
         if (br.hasErrors()){
-            String errorName = br.getAllErrors().get(0).getDefaultMessage(); //dto에 선언한 에러
+            String errorName = br.getAllErrors().get(0).getDefaultMessage();
             log.error(errorName);
             return new BaseResponse<>(errorName);
         }
@@ -36,5 +37,21 @@ public class ChatController {
         } catch(BaseException e){
             return new BaseResponse<>(e.getStatus());
         }
+    }
+
+    @PostMapping("/room")
+    public BaseResponse<ChatRoomResDto> createChatRoom(@Valid @RequestBody ChatRoomReqDto chatRoomReqDto, BindingResult br){
+        if (br.hasErrors()){
+            String errorName = br.getAllErrors().get(0).getDefaultMessage();
+            log.error(errorName);
+            return new BaseResponse<>(errorName);
+        }
+
+        try {
+            return new BaseResponse<>(chatService.createChatRoom(chatRoomReqDto));
+        } catch(BaseException e){
+            return new BaseResponse<>(e.getStatus());
+        }
+
     }
 }

--- a/src/main/java/com/sejongmate/chat/presentation/dto/ChatMessageReqDto.java
+++ b/src/main/java/com/sejongmate/chat/presentation/dto/ChatMessageReqDto.java
@@ -1,0 +1,37 @@
+package com.sejongmate.chat.presentation.dto;
+
+import com.sejongmate.chat.domain.MessageType;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatMessageReqDto {
+    @NotNull(message = "메세지 타입을 입력하세요.")
+    private MessageType type;
+    @NotNull(message = "room id를 입력하세요.")
+    private String roomId;
+    @NotNull(message = "sender id를 입력하세요.")
+    private Long senderId;
+    @NotNull(message = "내용을 입력하세요.")
+    private String content;
+    private LocalDateTime createdAt;
+    private Boolean isNotice;
+    private String fileUrl;
+
+    @Builder
+    public ChatMessageReqDto(MessageType type, String roomId, Long senderId, String content, LocalDateTime createdAt, Boolean isNotice, String fileUrl) {
+        this.type = type;
+        this.roomId = roomId;
+        this.senderId = senderId;
+        this.content = content;
+        this.createdAt = createdAt;
+        this.isNotice = isNotice;
+        this.fileUrl = fileUrl;
+    }
+}

--- a/src/main/java/com/sejongmate/chat/presentation/dto/ChatMessageReqDto.java
+++ b/src/main/java/com/sejongmate/chat/presentation/dto/ChatMessageReqDto.java
@@ -7,7 +7,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -16,22 +15,18 @@ public class ChatMessageReqDto {
     private MessageType type;
     @NotNull(message = "room id를 입력하세요.")
     private String roomId;
-    @NotNull(message = "sender id를 입력하세요.")
-    private Long senderId;
+    @NotNull(message = "sender num를 입력하세요.")
+    private String senderNum;
     @NotNull(message = "내용을 입력하세요.")
     private String content;
-    private LocalDateTime createdAt;
-    private Boolean isNotice;
     private String fileUrl;
 
     @Builder
-    public ChatMessageReqDto(MessageType type, String roomId, Long senderId, String content, LocalDateTime createdAt, Boolean isNotice, String fileUrl) {
+    public ChatMessageReqDto(MessageType type, String roomId, String senderNum, String content, String fileUrl) {
         this.type = type;
         this.roomId = roomId;
-        this.senderId = senderId;
+        this.senderNum = senderNum;
         this.content = content;
-        this.createdAt = createdAt;
-        this.isNotice = isNotice;
         this.fileUrl = fileUrl;
     }
 }

--- a/src/main/java/com/sejongmate/chat/presentation/dto/ChatMessageResDto.java
+++ b/src/main/java/com/sejongmate/chat/presentation/dto/ChatMessageResDto.java
@@ -1,0 +1,25 @@
+package com.sejongmate.chat.presentation.dto;
+
+import com.sejongmate.chat.domain.ChatMessage;
+import com.sejongmate.chat.domain.ChatMessageRepository;
+import com.sejongmate.user.domain.User;
+import com.sejongmate.user.presentation.dto.UserCreateResDto;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ChatMessageResDto {
+    Long id;
+    LocalDateTime createdAt;
+
+    public static ChatMessageResDto from(ChatMessage chatMessage){
+        return ChatMessageResDto.builder()
+                .id(chatMessage.getId())
+                .createdAt(chatMessage.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/sejongmate/chat/presentation/dto/ChatRoomHistoryDto.java
+++ b/src/main/java/com/sejongmate/chat/presentation/dto/ChatRoomHistoryDto.java
@@ -1,0 +1,26 @@
+package com.sejongmate.chat.presentation.dto;
+
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ChatRoomHistoryDto {
+    private String name;
+    private String profileUrl;
+    private String content;
+    private LocalDateTime createdAt;
+
+    @Builder @QueryProjection
+    public ChatRoomHistoryDto(String name, String profileUrl, String content, LocalDateTime createdAt) {
+        this.name = name;
+        this.profileUrl = profileUrl;
+        this.content = content;
+        this.createdAt = createdAt;
+    }
+}

--- a/src/main/java/com/sejongmate/chat/presentation/dto/ChatRoomInfoDto.java
+++ b/src/main/java/com/sejongmate/chat/presentation/dto/ChatRoomInfoDto.java
@@ -1,0 +1,25 @@
+package com.sejongmate.chat.presentation.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ChatRoomInfoDto {
+    String roomId;
+    String name;
+    LocalDateTime lastMessageAt;
+    String lastMessage;
+    Integer num;
+
+    @Builder @QueryProjection
+    public ChatRoomInfoDto(String roomId, String name, LocalDateTime lastMessageAt, String lastMessage, Integer num) {
+        this.roomId = roomId;
+        this.name = name;
+        this.lastMessageAt = lastMessageAt;
+        this.lastMessage = lastMessage;
+        this.num = num;
+    }
+}

--- a/src/main/java/com/sejongmate/chat/presentation/dto/ChatRoomReqDto.java
+++ b/src/main/java/com/sejongmate/chat/presentation/dto/ChatRoomReqDto.java
@@ -1,0 +1,19 @@
+package com.sejongmate.chat.presentation.dto;
+
+import com.sejongmate.chat.domain.ChatParticipant;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatRoomReqDto {
+    @NotNull(message = "채팅방 이름을 입력하세요.")
+    private String name;
+    private List<String> participantNum;
+}

--- a/src/main/java/com/sejongmate/chat/presentation/dto/ChatRoomResDto.java
+++ b/src/main/java/com/sejongmate/chat/presentation/dto/ChatRoomResDto.java
@@ -1,0 +1,21 @@
+package com.sejongmate.chat.presentation.dto;
+import com.sejongmate.chat.domain.ChatRoom;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ChatRoomResDto {
+    String id;
+    LocalDateTime createdAt;
+
+    public static ChatRoomResDto from(ChatRoom chatRoom){
+        return ChatRoomResDto.builder()
+                .id(chatRoom.getId())
+                .createdAt(chatRoom.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/sejongmate/common/BaseResponseStatus.java
+++ b/src/main/java/com/sejongmate/common/BaseResponseStatus.java
@@ -30,6 +30,8 @@ public enum BaseResponseStatus {
     INVALID_USER_NUM(false, 2106, "학번을 확인해주세요"),
     INVALID_USER_PW(false, 2106, "비밀번호를 확인해주세요."),
 
+    INVALID_CHATROOM(false, 2201, "채팅룸 ID를 확인해주세요."),
+
     /**
      * 3000 : Response 오류
      */

--- a/src/main/java/com/sejongmate/common/util/DeduplicationUtils.java
+++ b/src/main/java/com/sejongmate/common/util/DeduplicationUtils.java
@@ -1,0 +1,20 @@
+package com.sejongmate.common.util;
+
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+public class DeduplicationUtils {
+    public static <T> List<T> deduplication(final List<T> list, Function<? super T,?> key){
+        return list.stream().filter(deduplication(key))
+                .collect(Collectors.toList());
+    }
+
+   private static <T> Predicate<T> deduplication(Function<? super T,?>key){
+        final Set<Object> set = ConcurrentHashMap.newKeySet();
+        return predicate -> set.add(key.apply(predicate));
+    }
+}

--- a/src/main/java/com/sejongmate/config/JpaQueryFactoryConfig.java
+++ b/src/main/java/com/sejongmate/config/JpaQueryFactoryConfig.java
@@ -1,0 +1,18 @@
+package com.sejongmate.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JpaQueryFactoryConfig {
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(){
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,17 +1,21 @@
 spring:
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://${SEJONGMATE_RDS_URL}:3306/sejongmatedb?serverTimezone=Asia/Seoul
-    username: ${SEJONGMATE_RDS_USER}
-    password: ${SEJONGMATE_RDS_PW}
+    url: jdbc:mysql://localhost:3306/test
+    username: root
+    password: Sejongmate!
+#    url: jdbc:mysql://${SEJONGMATE_RDS_URL}:3306/sejongmatedb?serverTimezone=Asia/Seoul
+#    username: ${SEJONGMATE_RDS_USER}
+#    password: ${SEJONGMATE_RDS_PW}
 
   jpa:
     hibernate:
-      ddl-auto: create # 실행 시점에 모든 테이블 다 지우고 다시 생성
+      ddl-auto: update 
     properties:
       hibernate:
 #        show_sql: true
         format_sql: true
+    generate-ddl: true
 
   jwt:
     secret: ${SEJONGMATE_JWT_KEY}


### PR DESCRIPTION
### 채팅 API 구현
- querydsl 환경 설정
- 유저 채팅방 목록 조회 [ GET : `api/chat/room/list/{user_id}` ]
- 채팅방 채팅 목록 조회 [ GET :`api/chat/room/{room_id}` ]
- 채팅방 생성 [ POST : `api/chat/room`]
- 채팅 생성(채팅 보내기) [ POST : `api/chat/message`]
- 채팅방 나가기 [ DELETE : `api/chat/room/{room_id}/{user_id}` ]